### PR TITLE
Implementing country details screen with Compose Navigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,8 @@ dependencies {
     implementation(libs.koin.android)
 
     implementation(libs.coil.compose)
+    implementation(libs.coil.svg)
+
 
     implementation(libs.androidx.ui.text.google.fonts)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.jetbrains.kotlin.serialization)
+    id("kotlin-parcelize")
 }
 
 android {
@@ -79,6 +82,15 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
+
+    // Jetpack Compose Navigation Integration
+    implementation(libs.androidx.navigation.compose)
+
+    // Navigation Views/Fragments Integration
+    implementation(libs.androidx.navigation.fragment.ktx)
+    implementation(libs.androidx.navigation.ui.ktx)
+
+    implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app/src/main/java/net/rossmanges/wmtakehome/MainActivity.kt
+++ b/app/src/main/java/net/rossmanges/wmtakehome/MainActivity.kt
@@ -25,7 +25,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val filteredCountries by countryViewModel.filteredCountries.collectAsState()
             RossWalmartTakehomeProjectTheme {
-                MainScreen(filteredCountries) { filterText ->
+                MainScreen(filteredCountries, countryViewModel.lazyListState) { filterText ->
                     countryViewModel.updateFilter(filterText)
                 }
             }

--- a/app/src/main/java/net/rossmanges/wmtakehome/ui/view/AppNavigation.kt
+++ b/app/src/main/java/net/rossmanges/wmtakehome/ui/view/AppNavigation.kt
@@ -1,0 +1,40 @@
+package net.rossmanges.wmtakehome.ui.view
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.toRoute
+import kotlinx.serialization.Serializable
+import net.rossmanges.wmtakehome.data.Country
+
+@Serializable
+sealed class Routes {
+    @Serializable
+    data object CountryList : Routes()
+
+    @Serializable
+    data class CountryDetail(val countryCode: String) : Routes()
+}
+
+@Composable
+fun CountryApp(countries: List<Country>) {
+    val navController = rememberNavController()
+
+    NavHost(navController = navController, startDestination = Routes.CountryList) {
+        composable<Routes.CountryList> {
+            CountryList(countries = countries) {
+                navController.navigate(Routes.CountryDetail(it))
+            }
+        }
+        composable<Routes.CountryDetail> { backStackEntry ->
+            val countryCode = backStackEntry.toRoute<Routes.CountryDetail>().countryCode
+            val country = countries.firstOrNull { it.code == countryCode }
+            if (country != null) {
+                CountryDetailCard(country) {
+                    navController.navigate(Routes.CountryList)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/net/rossmanges/wmtakehome/ui/view/AppNavigation.kt
+++ b/app/src/main/java/net/rossmanges/wmtakehome/ui/view/AppNavigation.kt
@@ -1,5 +1,8 @@
 package net.rossmanges.wmtakehome.ui.view
 
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -17,22 +20,33 @@ sealed class Routes {
     data class CountryDetail(val countryCode: String) : Routes()
 }
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
-fun CountryApp(countries: List<Country>) {
+fun CountryApp(countries: List<Country>, lazyListState: LazyListState) {
     val navController = rememberNavController()
-
-    NavHost(navController = navController, startDestination = Routes.CountryList) {
-        composable<Routes.CountryList> {
-            CountryList(countries = countries) {
-                navController.navigate(Routes.CountryDetail(it))
+    SharedTransitionLayout {
+        NavHost(navController = navController, startDestination = Routes.CountryList) {
+            composable<Routes.CountryList> {
+                CountryList(
+                    lazyListState = lazyListState,
+                    countries = countries,
+                    animatedVisibilityScope = this@composable,
+                    sharedTransitionScope = this@SharedTransitionLayout
+                ) {
+                    navController.navigate(Routes.CountryDetail(it))
+                }
             }
-        }
-        composable<Routes.CountryDetail> { backStackEntry ->
-            val countryCode = backStackEntry.toRoute<Routes.CountryDetail>().countryCode
-            val country = countries.firstOrNull { it.code == countryCode }
-            if (country != null) {
-                CountryDetailCard(country) {
-                    navController.navigate(Routes.CountryList)
+            composable<Routes.CountryDetail> { backStackEntry ->
+                val countryCode = backStackEntry.toRoute<Routes.CountryDetail>().countryCode
+                val country = countries.firstOrNull { it.code == countryCode }
+                if (country != null) {
+                    CountryDetailCard(
+                        country = country,
+                        animatedVisibilityScope = this@composable,
+                        sharedTransitionScope = this@SharedTransitionLayout
+                    ) {
+                        navController.navigate(Routes.CountryList)
+                    }
                 }
             }
         }

--- a/app/src/main/java/net/rossmanges/wmtakehome/ui/view/CountryComposables.kt
+++ b/app/src/main/java/net/rossmanges/wmtakehome/ui/view/CountryComposables.kt
@@ -1,5 +1,10 @@
+@file:OptIn(ExperimentalSharedTransitionApi::class)
+
 package net.rossmanges.wmtakehome.ui.view
 
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
@@ -24,14 +30,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import net.rossmanges.wmtakehome.R
 import net.rossmanges.wmtakehome.data.Country
-import net.rossmanges.wmtakehome.data.Currency
-import net.rossmanges.wmtakehome.data.Language
 import net.rossmanges.wmtakehome.ui.theme.RossWmtTypography
 
 
@@ -40,65 +43,56 @@ import net.rossmanges.wmtakehome.ui.theme.RossWmtTypography
  * @param   country The [Country] data class.
  */
 @Composable
-fun CountryCard(country: Country, onClick: (String) -> Unit) {
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)
-            .clickable { onClick(country.code) },
-        shape = RoundedCornerShape(8.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surface
-        ),
-        elevation = CardDefaults.cardElevation(4.dp)
-    ) {
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+fun CountryCard(
+    country: Country,
+    animatedVisibilityScope: AnimatedVisibilityScope,
+    sharedTransitionScope: SharedTransitionScope,
+    onClick: (String) -> Unit
+) {
+    with(sharedTransitionScope) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+                .sharedBounds(
+                    sharedContentState = rememberSharedContentState(key = "card-${country.code}"),
+                    animatedVisibilityScope = animatedVisibilityScope
+                )
+                .clickable { onClick(country.code) },
+            shape = RoundedCornerShape(8.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            elevation = CardDefaults.cardElevation(4.dp)
         ) {
-            Row {
-                Text(
-                    text = "${country.name}, ${country.region}",
-                    style = RossWmtTypography.headlineSmall
-                )
-                Spacer(Modifier.weight(1f))
-                Text(
-                    text = country.code,
-                    style = RossWmtTypography.headlineSmall
-                )
-            }
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                CountryAndCode(country, animatedVisibilityScope)
 
-            Row {
-                Column {
-                    Text(
-                        text = "Capital: ${country.capital}",
-                        style = RossWmtTypography.bodyMedium
-                    )
-                    val currencySymbol = if (country.currency.symbol == null) "" else ", (${country.currency.symbol})"
-                    Text(
-                        text = "${country.currency.name}$currencySymbol",
-                        style = RossWmtTypography.bodyMedium
-                    )
-                    Text(
-                        text = "${country.language.name}",
-                        style = RossWmtTypography.bodyMedium
+                Row {
+                    CountryMetadata(country, animatedVisibilityScope)
+                    Spacer(Modifier.weight(1f))
+                    AsyncImage(
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data("https://flagcdn.com/w320/${country.code.lowercase()}.jpg")
+                            .crossfade(true)
+                            .build(),
+                        contentDescription = "Country flag",
+                        modifier = Modifier
+                            .width(80.dp)
+                            .align(Alignment.Bottom)
+                            .clip(RoundedCornerShape(3.dp))
+                            .sharedElement(
+                                state = rememberSharedContentState(key = country.code),
+                                animatedVisibilityScope = animatedVisibilityScope
+                            ),
+                        contentScale = ContentScale.Fit,
+                        placeholder = painterResource(id = R.drawable.flag_placeholder),
+                        error = painterResource(id = R.drawable.flag_error_placeholder)
                     )
                 }
-                Spacer(Modifier.weight(1f))
-                AsyncImage(
-                    model = ImageRequest.Builder(LocalContext.current)
-                        .data("https://flagcdn.com/w320/${country.code.lowercase()}.jpg")
-                        .crossfade(true)
-                        .build(),
-                    contentDescription = "Country flag",
-                    modifier = Modifier
-                        .width(80.dp)
-                        .align(Alignment.Bottom)
-                        .clip(RoundedCornerShape(3.dp)),
-                    contentScale = ContentScale.Fit,
-                    placeholder = painterResource(id = R.drawable.flag_placeholder),
-                    error = painterResource(id = R.drawable.flag_error_placeholder)
-                )
             }
         }
     }
@@ -109,12 +103,25 @@ fun CountryCard(country: Country, onClick: (String) -> Unit) {
  * @param countries The list of [Country] data to use in the list.
  */
 @Composable
-fun CountryList(countries: List<Country>, onClick: (String) -> Unit) {
+fun CountryList(
+    countries: List<Country>,
+    lazyListState: LazyListState,
+    animatedVisibilityScope: AnimatedVisibilityScope,
+    sharedTransitionScope: SharedTransitionScope,
+    onClick: (String) -> Unit
+) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
+        state = lazyListState,
     ) {
         items(countries) { country ->
-            CountryCard(country = country) { onClick(it) }
+            CountryCard(
+                country = country,
+                animatedVisibilityScope = animatedVisibilityScope,
+                sharedTransitionScope = sharedTransitionScope
+            ) {
+                onClick(it)
+            }
         }
     }
 }
@@ -138,42 +145,102 @@ fun NoDataMessage() {
     }
 }
 
-@Preview(showBackground = true)
 @Composable
-private fun PreviewCountryCard() {
-    val sampleCountry = listOf(
-        Country(
-        capital = "Charlotte Amalie",
-        code = "VI",
-        currency = Currency(
-            code = "USD",
-            name = "United States dollar",
-            symbol = "$"
-        ),
-        flag = "https://restcountries.eu/data/vir.svg",
-        language = Language(
-            code = "en",
-            name = "English"
-        ),
-        name = "Virgin Islands (U.S.)",
-        region = "NA"
-    ),
-        Country(
-            capital = "Flying Fish Cove",
-            code = "CX",
-            currency = Currency(
-                code = "AUD",
-                name = "Australian dollar",
-                symbol = "$"
+internal fun SharedTransitionScope.CountryAndCode(
+    country: Country,
+    animatedVisibilityScope: AnimatedVisibilityScope
+) {
+    Row {
+        Text(
+            modifier = Modifier.sharedBounds(
+                sharedContentState = rememberSharedContentState(key = "text-country-${country.code}"),
+                animatedVisibilityScope = animatedVisibilityScope
             ),
-            flag = "https://restcountries.eu/data/cxr.svg",
-            language = Language(
-                code = "en",
-                name = "English"
-            ),
-            name = "Christmas Island",
-            region = "OC"
+            text = "${country.name}, ${country.region}",
+            style = RossWmtTypography.headlineSmall
         )
-    )
-    CountryList(countries = sampleCountry) { }
+        Spacer(Modifier.weight(1f))
+        Text(
+            modifier = Modifier.sharedBounds(
+                sharedContentState = rememberSharedContentState(key = "text-country-code-${country.code}"),
+                animatedVisibilityScope = animatedVisibilityScope
+            ),
+            text = country.code,
+            style = RossWmtTypography.headlineSmall
+        )
+    }
 }
+
+@Composable
+internal fun SharedTransitionScope.CountryMetadata(
+    country: Country,
+    animatedVisibilityScope: AnimatedVisibilityScope) {
+    Column {
+        Text(
+            modifier = Modifier.sharedBounds(
+                sharedContentState = rememberSharedContentState(key = "text-country-cap-${country.code}"),
+                animatedVisibilityScope = animatedVisibilityScope
+            ),
+            text = "Capital: ${country.capital}",
+            style = RossWmtTypography.bodyMedium
+        )
+        val currencySymbol =
+            if (country.currency.symbol == null) "" else ", (${country.currency.symbol})"
+        Text(
+            modifier = Modifier.sharedBounds(
+                sharedContentState = rememberSharedContentState(key = "text-country-currency-${country.code}"),
+                animatedVisibilityScope = animatedVisibilityScope
+            ),
+            text = "${country.currency.name}$currencySymbol",
+            style = RossWmtTypography.bodyMedium
+        )
+        Text(
+            modifier = Modifier.sharedBounds(
+                sharedContentState = rememberSharedContentState(key = "text-country-language-${country.code}"),
+                animatedVisibilityScope = animatedVisibilityScope
+            ),
+            text = "${country.language.name}",
+            style = RossWmtTypography.bodyMedium
+        )
+    }
+}
+
+//@Preview(showBackground = true)
+//@Composable
+//private fun PreviewCountryCard() {
+//    val sampleCountry = listOf(
+//        Country(
+//        capital = "Charlotte Amalie",
+//        code = "VI",
+//        currency = Currency(
+//            code = "USD",
+//            name = "United States dollar",
+//            symbol = "$"
+//        ),
+//        flag = "https://restcountries.eu/data/vir.svg",
+//        language = Language(
+//            code = "en",
+//            name = "English"
+//        ),
+//        name = "Virgin Islands (U.S.)",
+//        region = "NA"
+//    ),
+//        Country(
+//            capital = "Flying Fish Cove",
+//            code = "CX",
+//            currency = Currency(
+//                code = "AUD",
+//                name = "Australian dollar",
+//                symbol = "$"
+//            ),
+//            flag = "https://restcountries.eu/data/cxr.svg",
+//            language = Language(
+//                code = "en",
+//                name = "English"
+//            ),
+//            name = "Christmas Island",
+//            region = "OC"
+//        )
+//    )
+//    CountryList(countries = sampleCountry) { }
+//}

--- a/app/src/main/java/net/rossmanges/wmtakehome/ui/view/CountryComposables.kt
+++ b/app/src/main/java/net/rossmanges/wmtakehome/ui/view/CountryComposables.kt
@@ -70,29 +70,7 @@ fun CountryCard(
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 CountryAndCode(country, animatedVisibilityScope)
-
-                Row {
-                    CountryMetadata(country, animatedVisibilityScope)
-                    Spacer(Modifier.weight(1f))
-                    AsyncImage(
-                        model = ImageRequest.Builder(LocalContext.current)
-                            .data("https://flagcdn.com/w320/${country.code.lowercase()}.jpg")
-                            .crossfade(true)
-                            .build(),
-                        contentDescription = "Country flag",
-                        modifier = Modifier
-                            .width(80.dp)
-                            .align(Alignment.Bottom)
-                            .clip(RoundedCornerShape(3.dp))
-                            .sharedElement(
-                                state = rememberSharedContentState(key = country.code),
-                                animatedVisibilityScope = animatedVisibilityScope
-                            ),
-                        contentScale = ContentScale.Fit,
-                        placeholder = painterResource(id = R.drawable.flag_placeholder),
-                        error = painterResource(id = R.drawable.flag_error_placeholder)
-                    )
-                }
+                Flag(country, animatedVisibilityScope)
             }
         }
     }
@@ -201,6 +179,35 @@ internal fun SharedTransitionScope.CountryMetadata(
             ),
             text = "${country.language.name}",
             style = RossWmtTypography.bodyMedium
+        )
+    }
+}
+
+@Composable
+internal fun SharedTransitionScope.Flag(
+    country: Country,
+    animatedVisibilityScope: AnimatedVisibilityScope
+) {
+    Row {
+        CountryMetadata(country, animatedVisibilityScope)
+        Spacer(Modifier.weight(1f))
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data("https://flagcdn.com/w320/${country.code.lowercase()}.jpg")
+                .crossfade(true)
+                .build(),
+            contentDescription = "Country flag",
+            modifier = Modifier
+                .width(80.dp)
+                .align(Alignment.Bottom)
+                .clip(RoundedCornerShape(3.dp))
+                .sharedElement(
+                    state = rememberSharedContentState(key = country.code),
+                    animatedVisibilityScope = animatedVisibilityScope
+                ),
+            contentScale = ContentScale.Fit,
+            placeholder = painterResource(id = R.drawable.flag_placeholder),
+            error = painterResource(id = R.drawable.flag_error_placeholder)
         )
     }
 }

--- a/app/src/main/java/net/rossmanges/wmtakehome/ui/view/CountryDetailComposables.kt
+++ b/app/src/main/java/net/rossmanges/wmtakehome/ui/view/CountryDetailComposables.kt
@@ -2,16 +2,12 @@ package net.rossmanges.wmtakehome.ui.view
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -24,23 +20,19 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import net.rossmanges.wmtakehome.R
 import net.rossmanges.wmtakehome.data.Country
-import net.rossmanges.wmtakehome.data.Currency
-import net.rossmanges.wmtakehome.data.Language
 import net.rossmanges.wmtakehome.ui.theme.RossWmtTypography
-
 
 /**
  * A container for presenting data about a country in a pleasing format.
  * @param   country The [Country] data class.
  */
 @Composable
-fun CountryCard(country: Country, onClick: (String) -> Unit) {
+fun CountryDetailCard(country: Country, onClick: (String) -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -102,78 +94,4 @@ fun CountryCard(country: Country, onClick: (String) -> Unit) {
             }
         }
     }
-}
-
-/**
- * A "lazy" column of [CountryCard]
- * @param countries The list of [Country] data to use in the list.
- */
-@Composable
-fun CountryList(countries: List<Country>, onClick: (String) -> Unit) {
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-    ) {
-        items(countries) { country ->
-            CountryCard(country = country) { onClick(it) }
-        }
-    }
-}
-
-/**
- * Displays a message centered on the screen that no data is available.
- */
-@Composable
-fun NoDataMessage() {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = "No Data Available",
-            style = MaterialTheme.typography.bodyLarge,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun PreviewCountryCard() {
-    val sampleCountry = listOf(
-        Country(
-        capital = "Charlotte Amalie",
-        code = "VI",
-        currency = Currency(
-            code = "USD",
-            name = "United States dollar",
-            symbol = "$"
-        ),
-        flag = "https://restcountries.eu/data/vir.svg",
-        language = Language(
-            code = "en",
-            name = "English"
-        ),
-        name = "Virgin Islands (U.S.)",
-        region = "NA"
-    ),
-        Country(
-            capital = "Flying Fish Cove",
-            code = "CX",
-            currency = Currency(
-                code = "AUD",
-                name = "Australian dollar",
-                symbol = "$"
-            ),
-            flag = "https://restcountries.eu/data/cxr.svg",
-            language = Language(
-                code = "en",
-                name = "English"
-            ),
-            name = "Christmas Island",
-            region = "OC"
-        )
-    )
-    CountryList(countries = sampleCountry) { }
 }

--- a/app/src/main/java/net/rossmanges/wmtakehome/ui/view/CountryDetailComposables.kt
+++ b/app/src/main/java/net/rossmanges/wmtakehome/ui/view/CountryDetailComposables.kt
@@ -1,17 +1,20 @@
-@file:OptIn(ExperimentalSharedTransitionApi::class)
+@file:OptIn(ExperimentalSharedTransitionApi::class, ExperimentalSharedTransitionApi::class)
 
 package net.rossmanges.wmtakehome.ui.view
 
+import android.util.Log
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -21,7 +24,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -60,53 +62,67 @@ fun CountryDetailCard(
             ),
             elevation = CardDefaults.cardElevation(4.dp)
         ) {
-            Column(
-                modifier = Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                CountryAndCode(country, animatedVisibilityScope)
-
-                Row {
-                    CountryMetadata(country, animatedVisibilityScope)
-                    Spacer(Modifier.weight(1f))
-                    AsyncImage(
-                        model = ImageRequest.Builder(LocalContext.current)
-                            .data("https://flagcdn.com/w320/${country.code.lowercase()}.jpg")
-                            .crossfade(true)
-                            .build(),
-                        contentDescription = "Country flag",
+            BoxWithConstraints {
+                Log.v("constraints", "maxWidth=$maxWidth")
+                if (maxWidth > 400.dp) {
+                    Row(
                         modifier = Modifier
-                            .width(80.dp)
-                            .align(Alignment.Bottom)
-                            .clip(RoundedCornerShape(3.dp))
-                            .sharedElement(
-                                state = rememberSharedContentState(key = country.code),
-                                animatedVisibilityScope = animatedVisibilityScope
-                            ),
-                        contentScale = ContentScale.Fit,
-                        placeholder = painterResource(id = R.drawable.flag_placeholder),
-                        error = painterResource(id = R.drawable.flag_error_placeholder)
-                    )
+                            .padding(16.dp)
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            CountryAndCode(country, animatedVisibilityScope)
+                            Flag(country, animatedVisibilityScope)
+                        }
+                        Column(
+                            modifier = Modifier
+                                .fillMaxHeight()
+                                .weight(1f),
+                            verticalArrangement = Arrangement.Center,
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            CountryShape(country)
+                        }
+                    }
+                } else {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        CountryAndCode(country, animatedVisibilityScope)
+                        Flag(country, animatedVisibilityScope)
+                    }
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CountryShape(country)
+                    }
                 }
-            }
-            Box(modifier = Modifier.fillMaxSize()) {
-                AsyncImage(
-                    // note: lifted this country-shape endpoint from Wordle, need to find a replacement.
-                    model = ImageRequest.Builder(LocalContext.current)
-                        .data("https://teuteuf-dashboard-assets.pages.dev/data/common/country-shapes/${country.code.lowercase()}.svg")
-                        .decoderFactory(SvgDecoder.Factory())
-                        .crossfade(true)
-                        .build(),
-                    contentDescription = "border map",
-                    modifier = Modifier
-                        .width(300.dp)
-                        .align(Alignment.Center),
-                    contentScale = ContentScale.Fit,
-                    error = painterResource(id = R.drawable.flag_error_placeholder)
-                )
             }
         }
     }
+}
+
+@Composable
+fun CountryShape(country: Country) {
+    AsyncImage(
+        // note: lifted this country-shape endpoint from Wordle, need to find a replacement.
+        model = ImageRequest.Builder(LocalContext.current)
+            .data("https://teuteuf-dashboard-assets.pages.dev/data/common/country-shapes/${country.code.lowercase()}.svg")
+            .decoderFactory(SvgDecoder.Factory())
+            .crossfade(true)
+            .build(),
+        contentDescription = "border map",
+        modifier = Modifier
+            .width(300.dp),
+        contentScale = ContentScale.Fit,
+        error = painterResource(id = R.drawable.flag_error_placeholder)
+    )
 }
 
 

--- a/app/src/main/java/net/rossmanges/wmtakehome/ui/view/CountryDetailComposables.kt
+++ b/app/src/main/java/net/rossmanges/wmtakehome/ui/view/CountryDetailComposables.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import coil.decode.SvgDecoder
 import coil.request.ImageRequest
 import net.rossmanges.wmtakehome.R
 import net.rossmanges.wmtakehome.data.Country
@@ -66,7 +67,8 @@ fun CountryDetailCard(country: Country, onClick: (String) -> Unit) {
                         text = "Capital: ${country.capital}",
                         style = RossWmtTypography.bodyMedium
                     )
-                    val currencySymbol = if (country.currency.symbol == null) "" else ", (${country.currency.symbol})"
+                    val currencySymbol =
+                        if (country.currency.symbol == null) "" else ", (${country.currency.symbol})"
                     Text(
                         text = "${country.currency.name}$currencySymbol",
                         style = RossWmtTypography.bodyMedium
@@ -92,6 +94,21 @@ fun CountryDetailCard(country: Country, onClick: (String) -> Unit) {
                     error = painterResource(id = R.drawable.flag_error_placeholder)
                 )
             }
+
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data("https://teuteuf-dashboard-assets.pages.dev/data/common/country-shapes/${country.code.lowercase()}.svg")
+                    .decoderFactory(SvgDecoder.Factory())
+                    .crossfade(true)
+                    .build(),
+                contentDescription = "border map",
+                modifier = Modifier
+                    .width(300.dp)
+                    .align(Alignment.CenterHorizontally),
+                contentScale = ContentScale.Fit,
+                placeholder = painterResource(id = R.drawable.flag_placeholder),
+                error = painterResource(id = R.drawable.flag_error_placeholder)
+            )
         }
     }
 }

--- a/app/src/main/java/net/rossmanges/wmtakehome/ui/view/MainScreenComposables.kt
+++ b/app/src/main/java/net/rossmanges/wmtakehome/ui/view/MainScreenComposables.kt
@@ -36,7 +36,7 @@ fun MainScreen(filteredCountries: List<Country>, onSearchTextChanged: (String) -
                 if (filteredCountries.isEmpty()) {
                     NoDataMessage()
                 } else {
-                    CountryList(countries = filteredCountries)
+                    CountryApp(countries = filteredCountries)
                 }
             }
         }

--- a/app/src/main/java/net/rossmanges/wmtakehome/ui/view/MainScreenComposables.kt
+++ b/app/src/main/java/net/rossmanges/wmtakehome/ui/view/MainScreenComposables.kt
@@ -2,6 +2,7 @@ package net.rossmanges.wmtakehome.ui.view
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -14,7 +15,11 @@ import net.rossmanges.wmtakehome.data.Country
  * The Composable function that describes the main scaffold and layout for this app.
  */
 @Composable
-fun MainScreen(filteredCountries: List<Country>, onSearchTextChanged: (String) -> Unit) {
+fun MainScreen(
+    filteredCountries: List<Country>,
+    lazyListState: LazyListState,
+    onSearchTextChanged: (String) -> Unit
+) {
     Scaffold(
         topBar = {
             TopAppBarWithSearch(
@@ -36,7 +41,7 @@ fun MainScreen(filteredCountries: List<Country>, onSearchTextChanged: (String) -
                 if (filteredCountries.isEmpty()) {
                     NoDataMessage()
                 } else {
-                    CountryApp(countries = filteredCountries)
+                    CountryApp(countries = filteredCountries, lazyListState = lazyListState)
                 }
             }
         }

--- a/app/src/main/java/net/rossmanges/wmtakehome/ui/viewmodel/CountryViewModel.kt
+++ b/app/src/main/java/net/rossmanges/wmtakehome/ui/viewmodel/CountryViewModel.kt
@@ -1,5 +1,8 @@
 package net.rossmanges.wmtakehome.ui.viewmodel
 
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,6 +21,7 @@ import net.rossmanges.wmtakehome.repository.CountryRepository
 class CountryViewModel(private val repository: CountryRepository) : ViewModel() {
     private val _filterText = MutableStateFlow("")
     private val _countries = MutableStateFlow<List<Country>>(emptyList())
+    val lazyListState: LazyListState by mutableStateOf( LazyListState(0,0))
 
     /**
      * The unfiltered list of [Country] data.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,4 +2,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.jetbrains.kotlin.serialization) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,21 +4,27 @@ coilCompose = "2.4.0"
 gson = "2.10.1"
 junitJupiter = "5.8.2"
 koinAndroid = "3.5.6"
-kotlin = "1.9.0"
+kotlin = "2.0.20"
 coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 kotlinxCoroutinesTest = "1.6.4"
+kotlinxSerializationJson = "1.7.3"
+kotlinxSerialization = "2.0.20"
 ktorClient = "2.3.12"
-lifecycleRuntimeKtx = "2.8.5"
+lifecycleRuntimeKtx = "2.8.6"
 activityCompose = "1.9.2"
-composeBom = "2024.09.01"
+composeBom = "2024.09.02"
 mockk = "1.13.1"
-uiTextGoogleFonts = "1.7.1"
+navigationCompose = "2.8.1"
+uiTextGoogleFonts = "1.7.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "navigationCompose" }
+androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationCompose" }
 androidx-ui-text-google-fonts = { module = "androidx.compose.ui:ui-text-google-fonts", version.ref = "uiTextGoogleFonts" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
@@ -40,6 +46,7 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.re
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koinAndroid" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktorClient" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktorClient" }
 ktor-client-json = { module = "io.ktor:ktor-client-json", version.ref = "ktorClient" }
@@ -51,4 +58,5 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-
+jetbrains-kotlin-serialization = { id ="org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinxSerialization"}
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fr
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigationCompose" }
 androidx-ui-text-google-fonts = { module = "androidx.compose.ui:ui-text-google-fonts", version.ref = "uiTextGoogleFonts" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
+coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coilCompose" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
## Changes:
* Implemented a second screen showing more details of the selected country.
* Used Compose Navigation to transition between the screens
* Refactored some of the Compose code to move duplicate layouts to common functions.
* Added shared element transition animations between the country "card" in the list and the detail "card".

## Known Issues:
* Still need to refactor the Compose Preview code to get it working again.